### PR TITLE
Refactor client generator to use openapi-python-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ A tool for converting OpenAPI specifications into Model Context Protocol (MCP) s
 OpenAPI-MCP bridges the gap between REST APIs and large language models by:
 
 1. Taking an OpenAPI specification as input
-2. Generating a Python client for the API
+2. Generating a Python client for the API using [openapi-python-client](https://github.com/openapi-generators/openapi-python-client)
 3. Creating an MCP wrapper that exposes the API to language models
 
 This allows any API defined with an OpenAPI spec to be used as an MCP server, making it accessible to Claude and other LLMs through the Model Context Protocol.
+
+The generated Python client features modern Python practices including type annotations, dataclasses, and async support.
 
 ## Project Status
 
@@ -32,6 +34,8 @@ This project is under active development. See our GitHub project board for statu
 # Not yet available - project in development
 pip install openapi-mcp
 ```
+
+No external dependencies like npm or Node.js are required, as this tool uses pure Python libraries.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "click>=8.0.0",
     "requests>=2.0.0",
     "wheel>=0.37.0",
+    "openapi-python-client>=0.16.0",
 ]
 
 [project.optional-dependencies]

--- a/src/openapi_mcp/cli.py
+++ b/src/openapi_mcp/cli.py
@@ -45,26 +45,33 @@ def generate(spec: Path, output: Path) -> None:
     type=str,
 )
 @click.option(
-    "--output", "-o",
+    "--output",
+    "-o",
     type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
     required=True,
     help="Output directory for generated client",
 )
 @click.option(
-    "--config", "-c",
+    "--config",
+    "-c",
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
     help="Path to generator configuration JSON file",
 )
 @click.option(
-    "--package", "-p",
+    "--package",
+    "-p",
     is_flag=True,
     help="Package the generated client as a wheel",
 )
-def generate_client(spec_path: str, output: Path, config: Optional[str] = None, package: bool = False) -> None:
+def generate_client(
+    spec_path: str, output: Path, config: Optional[str] = None, package: bool = False
+) -> None:
     """
-    Generate a Python client from an OpenAPI specification.
-    
+    Generate a Python client from an OpenAPI specification using openapi-python-client.
+
     SPEC_PATH can be a local file path or a URL pointing to an OpenAPI specification.
+
+    The generated client provides modern Python features like type annotations and dataclasses.
     """
     try:
         # Load configuration if provided
@@ -72,28 +79,32 @@ def generate_client(spec_path: str, output: Path, config: Optional[str] = None, 
         if config:
             with open(config, "r", encoding="utf-8") as f:
                 generator_config = json.load(f)
-        
+
         click.echo(f"Generating Python client from {spec_path} to {output}")
-        
+
         # Initialize generator
         generator = ClientGenerator()
-        
+
         # Load specification
         try:
             generator.load_spec(spec_path)
             click.secho("✓ OpenAPI specification loaded and validated", fg="green")
         except (ValueError, FileNotFoundError, requests.RequestException) as e:
-            click.secho(f"Error: Failed to load specification: {str(e)}", fg="red", err=True)
+            click.secho(
+                f"Error: Failed to load specification: {str(e)}", fg="red", err=True
+            )
             sys.exit(1)
-        
+
         # Generate client
         try:
             client_dir = generator.generate_client(output, generator_config)
             click.secho(f"✓ Client generated successfully at {client_dir}", fg="green")
         except RuntimeError as e:
-            click.secho(f"Error: Failed to generate client: {str(e)}", fg="red", err=True)
+            click.secho(
+                f"Error: Failed to generate client: {str(e)}", fg="red", err=True
+            )
             sys.exit(1)
-        
+
         # Package client if requested
         if package:
             try:
@@ -101,9 +112,11 @@ def generate_client(spec_path: str, output: Path, config: Optional[str] = None, 
                 wheel_path = generator.package_client(client_dir)
                 click.secho(f"✓ Client packaged successfully: {wheel_path}", fg="green")
             except (ValueError, RuntimeError) as e:
-                click.secho(f"Error: Failed to package client: {str(e)}", fg="red", err=True)
+                click.secho(
+                    f"Error: Failed to package client: {str(e)}", fg="red", err=True
+                )
                 sys.exit(1)
-        
+
     except Exception as e:
         click.secho(f"Error: {str(e)}", fg="red", err=True)
         sys.exit(1)
@@ -115,18 +128,19 @@ def generate_client(spec_path: str, output: Path, config: Optional[str] = None, 
     type=str,
 )
 @click.option(
-    "--verbose", "-v",
+    "--verbose",
+    "-v",
     is_flag=True,
     help="Show detailed information about the specification",
 )
 def validate(spec_path: str, verbose: bool) -> None:
     """
     Validate an OpenAPI specification file or URL.
-    
+
     SPEC_PATH can be a local file path or a URL pointing to an OpenAPI specification.
     """
     processor = SpecProcessor()
-    
+
     try:
         # Determine if path is URL or file
         if spec_path.startswith(("http://", "https://")):
@@ -137,39 +151,39 @@ def validate(spec_path: str, verbose: bool) -> None:
             if not file_path.exists():
                 click.echo(f"Error: File not found: {spec_path}", err=True)
                 sys.exit(1)
-            
+
             click.echo(f"Validating OpenAPI specification file: {spec_path}")
             spec = processor.load_from_file(file_path)
-        
+
         # Basic validation is already done in the processor
-        
+
         # Display validation success
         click.secho("✓ Valid OpenAPI specification", fg="green")
-        
+
         # Show additional information if verbose
         if verbose:
             info = spec.get("info", {})
             click.echo(f"\nTitle: {info.get('title', 'Not specified')}")
             click.echo(f"Version: {info.get('version', 'Not specified')}")
             click.echo(f"OpenAPI Version: {spec.get('openapi', 'Not specified')}")
-            
+
             # Count endpoints
             endpoints = processor.extract_endpoints()
             click.echo(f"Endpoints: {len(endpoints)}")
-            
+
             # Count schemas
             schemas = processor.get_schemas()
             click.echo(f"Schemas: {len(schemas)}")
-            
+
             # Show endpoint summary if there are any
             if endpoints:
                 click.echo("\nEndpoints:")
                 for endpoint in endpoints:
-                    method = endpoint['method']
-                    path = endpoint['path']
-                    summary = endpoint['summary'] or 'No summary'
+                    method = endpoint["method"]
+                    path = endpoint["path"]
+                    summary = endpoint["summary"] or "No summary"
                     click.echo(f"  {method} {path} - {summary}")
-        
+
     except (ValueError, FileNotFoundError, requests.RequestException) as e:
         click.secho(f"Error: {str(e)}", fg="red", err=True)
         sys.exit(1)

--- a/src/openapi_mcp/client_generator.py
+++ b/src/openapi_mcp/client_generator.py
@@ -2,15 +2,18 @@
 Client generator module for OpenAPI-MCP.
 
 This module provides functionality to generate Python clients from
-OpenAPI specifications using openapi-generator-cli.
+OpenAPI specifications using openapi-python-client.
 """
 
 import os
 import shutil
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
+import json
+
+from openapi_python_client import GeneratorError, generate
+from openapi_python_client.config import ConfigFile, Config, MetaType
 
 from openapi_mcp.spec_processor import SpecProcessor
 
@@ -18,57 +21,30 @@ from openapi_mcp.spec_processor import SpecProcessor
 class ClientGenerator:
     """
     Generate Python clients from OpenAPI specifications.
-    
+
     This class provides methods to generate Python client libraries from
-    OpenAPI specifications using openapi-generator-cli.
+    OpenAPI specifications using openapi-python-client.
     """
-    
+
     def __init__(self, spec_processor: Optional[SpecProcessor] = None) -> None:
         """
         Initialize the client generator.
-        
+
         Args:
             spec_processor: Optional SpecProcessor instance with a loaded spec
         """
         self.spec_processor = spec_processor or SpecProcessor()
-        self._check_generator_cli()
-    
-    def _check_generator_cli(self) -> None:
-        """
-        Check if openapi-generator-cli is available.
-        
-        Raises:
-            RuntimeError: If openapi-generator-cli is not available
-        """
-        try:
-            result = subprocess.run(
-                ["openapi-generator-cli", "version"],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            
-            if result.returncode != 0:
-                raise RuntimeError(
-                    "openapi-generator-cli is not available. "
-                    "Please install it first: npm install @openapitools/openapi-generator-cli -g"
-                )
-        except FileNotFoundError:
-            raise RuntimeError(
-                "openapi-generator-cli is not available. "
-                "Please install it first: npm install @openapitools/openapi-generator-cli -g"
-            )
-    
+
     def load_spec(self, spec_path: Union[str, Path]) -> Dict[str, Any]:
         """
         Load an OpenAPI specification.
-        
+
         Args:
             spec_path: Path or URL to the OpenAPI specification
-            
+
         Returns:
             Dict containing the parsed OpenAPI specification
-            
+
         Raises:
             ValueError: If the spec path is invalid or the spec is invalid
         """
@@ -76,7 +52,7 @@ class ClientGenerator:
             return self.spec_processor.load_from_url(spec_path)
         else:
             return self.spec_processor.load_from_file(spec_path)
-    
+
     def generate_client(
         self,
         output_dir: Union[str, Path],
@@ -84,108 +60,116 @@ class ClientGenerator:
     ) -> Path:
         """
         Generate a Python client from the loaded OpenAPI specification.
-        
+
         Args:
             output_dir: Directory where the generated client will be saved
             config: Optional configuration for the generator
-            
+
         Returns:
             Path to the generated client
-            
+
         Raises:
             ValueError: If no specification is loaded
             RuntimeError: If the client generation fails
         """
         if not hasattr(self.spec_processor, "spec") or not self.spec_processor.spec:
             raise ValueError("No specification loaded. Call load_spec() first.")
-        
+
         # Create temporary directory for spec file
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_spec_path = Path(temp_dir) / "openapi.json"
-            
+
             # Write the spec to a temporary file
             with open(temp_spec_path, "w", encoding="utf-8") as f:
-                import json
                 json.dump(self.spec_processor.spec, f)
-            
+
             # Prepare output directory
             output_path = Path(output_dir)
             output_path.mkdir(parents=True, exist_ok=True)
-            
-            # Basic configuration
-            base_config = {
-                "generateSourceCodeOnly": "true",
-                "packageName": "openapi_client",
-                "library": "urllib3",
-            }
-            
-            # Merge with user config
+
+            # Create a default config
+            config_file = ConfigFile()
+
+            # Convert custom config settings if provided
             if config:
-                base_config.update(config)
-            
-            # Prepare config options
-            config_options = [
-                f"--additional-properties={key}={value}"
-                for key, value in base_config.items()
-            ]
-            
-            # Execute openapi-generator-cli
-            cmd = [
-                "openapi-generator-cli", "generate",
-                "-i", str(temp_spec_path),
-                "-g", "python",
-                "-o", str(output_path),
-                *config_options,
-            ]
-            
+                # Map camelCase to snake_case for compatibility
+                if "packageName" in config:
+                    config["package_name_override"] = config.pop("packageName")
+                if "projectName" in config:
+                    config["project_name_override"] = config.pop("projectName")
+
+                # Apply configuration to ConfigFile
+                for key, value in config.items():
+                    if hasattr(config_file, key):
+                        setattr(config_file, key, value)
+
+            # Generate the final Config from ConfigFile
+            generator_config = Config.from_sources(
+                config_file=config_file,
+                meta_type=MetaType.NONE,  # No meta builder like Poetry or PDM
+                document_source=temp_spec_path,
+                file_encoding="utf-8",
+                overwrite=True,
+                output_path=output_path,
+            )
+
             try:
-                result = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-                
-                if result.returncode != 0:
-                    raise RuntimeError(
-                        f"Client generation failed: {result.stderr}"
-                    )
+                # Generate client
+                result = generate(config=generator_config)
+
+                if result:  # If there are any errors
+                    error_details = ", ".join(str(error) for error in result)
+                    raise RuntimeError(f"Client generation failed: {error_details}")
+
+                # Return the path to the generated client
+                return output_path
+
             except Exception as e:
                 raise RuntimeError(f"Failed to generate client: {str(e)}")
-            
-            return output_path
-    
+
     def validate_generated_client(self, client_dir: Union[str, Path]) -> bool:
         """
         Validate the generated client.
-        
+
         Args:
             client_dir: Directory containing the generated client
-            
+
         Returns:
             True if the client is valid
-            
+
         Raises:
             ValueError: If the client directory does not exist or is invalid
         """
         client_dir = Path(client_dir)
-        
+
         if not client_dir.exists() or not client_dir.is_dir():
             raise ValueError(f"Client directory does not exist: {client_dir}")
-        
+
+        # Check for package structure
+        package_name = None
+
+        # Try to find a Python package in the client directory
+        for item in client_dir.iterdir():
+            if item.is_dir() and (item / "__init__.py").exists():
+                package_name = item.name
+                break
+
+        if not package_name:
+            raise ValueError("Invalid client: No Python package found")
+
         # Check for key files
         required_files = [
-            "openapi_client/__init__.py",
-            "openapi_client/api_client.py",
-            "setup.py",
+            f"{package_name}/__init__.py",
+            f"{package_name}/client.py",
+            "pyproject.toml",
         ]
-        
+
         for rel_path in required_files:
             if not (client_dir / rel_path).exists():
                 raise ValueError(f"Invalid client: missing {rel_path}")
-        
+
         return True
-    
+
     def package_client(
         self,
         client_dir: Union[str, Path],
@@ -193,62 +177,64 @@ class ClientGenerator:
     ) -> Path:
         """
         Package the generated client into a distribution format.
-        
+
         Args:
             client_dir: Directory containing the generated client
             output_file: Optional path for the packaged client
-            
+
         Returns:
             Path to the packaged client
-            
+
         Raises:
             ValueError: If the client directory does not exist
             RuntimeError: If the packaging fails
         """
         client_dir = Path(client_dir)
-        
+
         if not client_dir.exists() or not client_dir.is_dir():
             raise ValueError(f"Client directory does not exist: {client_dir}")
-        
+
         # Validate the client first
         self.validate_generated_client(client_dir)
-        
+
         # Change to the client directory and build the package
         current_dir = os.getcwd()
         try:
             os.chdir(client_dir)
-            
-            # Execute setup.py to build distribution
-            cmd = ["python", "setup.py", "sdist", "bdist_wheel"]
+
+            # Execute pip to build distribution
+            import subprocess
+
+            cmd = ["python", "-m", "build", "--wheel"]
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
                 check=False,
             )
-            
+
             if result.returncode != 0:
                 raise RuntimeError(f"Client packaging failed: {result.stderr}")
-            
+
             # Find the wheel file
             dist_dir = client_dir / "dist"
             wheels = list(dist_dir.glob("*.whl"))
-            
+
             if not wheels:
                 raise RuntimeError("No wheel file found after packaging")
-            
+
             # Get the most recent wheel
             wheel_path = max(wheels, key=lambda p: p.stat().st_mtime)
-            
+
             # Copy to the output location if specified
             if output_file:
                 output_path = Path(output_file)
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy(wheel_path, output_path)
                 return output_path
-            
+
             return wheel_path
-            
+
         except Exception as e:
             raise RuntimeError(f"Failed to package client: {str(e)}")
         finally:

--- a/src/openapi_mcp/spec_processor.py
+++ b/src/openapi_mcp/spec_processor.py
@@ -17,34 +17,34 @@ from urllib.parse import urlparse
 class SpecProcessor:
     """
     Process OpenAPI specifications from file or URL.
-    
+
     This class provides methods to load, validate, and extract information from
     OpenAPI specifications.
     """
-    
+
     def __init__(self) -> None:
         """Initialize the spec processor."""
         self.spec: Dict[str, Any] = {}
-    
+
     def load_from_file(self, file_path: Union[str, Path]) -> Dict[str, Any]:
         """
         Load an OpenAPI specification from a file.
-        
+
         Args:
             file_path: Path to the OpenAPI specification file (JSON or YAML)
-            
+
         Returns:
             Dict containing the parsed OpenAPI specification
-            
+
         Raises:
             FileNotFoundError: If the file does not exist
             ValueError: If the file format is not supported or content is invalid
         """
         file_path = Path(file_path)
-        
+
         if not file_path.exists():
             raise FileNotFoundError(f"Specification file not found: {file_path}")
-        
+
         # Read and parse based on file extension
         suffix = file_path.suffix.lower()
         if suffix in (".yaml", ".yml"):
@@ -61,22 +61,22 @@ class SpecProcessor:
                     raise ValueError(f"Invalid JSON format: {e}")
         else:
             raise ValueError(f"Unsupported file format: {suffix}")
-        
+
         # Validate the loaded spec
         self.validate_spec()
-        
+
         return self.spec
-    
+
     def load_from_url(self, url: str) -> Dict[str, Any]:
         """
         Load an OpenAPI specification from a URL.
-        
+
         Args:
             url: URL pointing to an OpenAPI specification (JSON or YAML)
-            
+
         Returns:
             Dict containing the parsed OpenAPI specification
-            
+
         Raises:
             ValueError: If the URL is invalid or content cannot be parsed
             requests.RequestException: If the request fails
@@ -85,24 +85,23 @@ class SpecProcessor:
         parsed_url = urlparse(url)
         if not all([parsed_url.scheme, parsed_url.netloc]):
             raise ValueError(f"Invalid URL: {url}")
-        
+
         # Fetch the spec from URL
         response = requests.get(url, timeout=30)
         response.raise_for_status()
-        
+
         content_type = response.headers.get("Content-Type", "")
-        
+
         # Parse based on content type or try to infer format
         if "application/json" in content_type:
             try:
                 self.spec = response.json()
             except json.JSONDecodeError as e:
                 raise ValueError(f"Invalid JSON response: {e}")
-        elif any(fmt in content_type for fmt in [
-            "application/yaml", 
-            "application/x-yaml", 
-            "text/yaml"
-        ]):
+        elif any(
+            fmt in content_type
+            for fmt in ["application/yaml", "application/x-yaml", "text/yaml"]
+        ):
             try:
                 self.spec = yaml.safe_load(response.text)
             except yaml.YAMLError as e:
@@ -116,25 +115,25 @@ class SpecProcessor:
                     self.spec = yaml.safe_load(response.text)
                 except yaml.YAMLError:
                     raise ValueError("Could not parse response as JSON or YAML")
-        
+
         # Validate the loaded spec
         self.validate_spec()
-        
+
         return self.spec
-    
+
     def validate_spec(self) -> bool:
         """
         Validate the loaded OpenAPI specification.
-        
+
         Returns:
             True if the specification is valid
-            
+
         Raises:
             ValueError: If the specification is invalid
         """
         if not self.spec:
             raise ValueError("No specification loaded")
-        
+
         # Basic structure validation
         required_fields = ["openapi", "info", "paths"]
         for field in required_fields:
@@ -142,7 +141,7 @@ class SpecProcessor:
                 raise ValueError(
                     f"Invalid OpenAPI specification: missing required field '{field}'"
                 )
-        
+
         # Validate OpenAPI version
         openapi_version = self.spec.get("openapi", "")
         if not openapi_version.startswith(("3.0", "3.1")):
@@ -150,43 +149,43 @@ class SpecProcessor:
                 f"Unsupported OpenAPI version: {openapi_version}. "
                 f"Expected 3.0.x or 3.1.x"
             )
-        
+
         # Validate info section
         info = self.spec.get("info", {})
         if not isinstance(info, dict) or "title" not in info or "version" not in info:
             raise ValueError(
                 "Invalid 'info' section: must contain 'title' and 'version'"
             )
-        
+
         # Validate paths section
         paths = self.spec.get("paths", {})
         if not isinstance(paths, dict):
             raise ValueError("Invalid 'paths' section: must be an object")
-            
+
         return True
-    
+
     def extract_endpoints(self) -> List[Dict[str, Any]]:
         """
         Extract API endpoints from the specification.
-        
+
         Returns:
             List of dictionaries containing endpoint information
-        
+
         Raises:
             ValueError: If no specification is loaded
         """
         if not self.spec:
             raise ValueError("No specification loaded")
-        
+
         endpoints = []
         paths = self.spec.get("paths", {})
-        
+
         for path, path_item in paths.items():
             for method, operation in path_item.items():
                 # Skip non-operation properties like parameters
                 if method in ["parameters", "servers", "summary", "description"]:
                     continue
-                    
+
                 endpoint = {
                     "path": path,
                     "method": method.upper(),
@@ -198,24 +197,24 @@ class SpecProcessor:
                     "responses": operation.get("responses", {}),
                 }
                 endpoints.append(endpoint)
-        
+
         return endpoints
-    
+
     def get_schemas(self) -> Dict[str, Any]:
         """
         Extract schema definitions from the specification.
-        
+
         Returns:
             Dictionary of schema definitions
-            
+
         Raises:
             ValueError: If no specification is loaded
         """
         if not self.spec:
             raise ValueError("No specification loaded")
-        
+
         components = self.spec.get("components", {})
         schemas = components.get("schemas", {})
-        
+
         # Explicitly cast to correct return type to satisfy mypy
         return dict(schemas)

--- a/tests/unit/test_client_generator.py
+++ b/tests/unit/test_client_generator.py
@@ -48,53 +48,10 @@ def spec_file(sample_spec, tmp_path):
     return spec_file
 
 
-@pytest.fixture
-def mock_generator():
-    """Mock the openapi-generator-cli commands."""
-    with mock.patch("subprocess.run") as mock_run:
-        # Mock the version check
-        version_result = mock.MagicMock()
-        version_result.returncode = 0
-        version_result.stdout = "5.0.0"
-        
-        # Mock the generate command
-        generate_result = mock.MagicMock()
-        generate_result.returncode = 0
-        
-        # Mock the package command
-        package_result = mock.MagicMock()
-        package_result.returncode = 0
-        
-        # Set up the side effects for different commands
-        def side_effect(cmd, **kwargs):
-            if "version" in cmd:
-                return version_result
-            elif "generate" in cmd:
-                return generate_result
-            elif "setup.py" in cmd:
-                return package_result
-            return mock.MagicMock()
-        
-        mock_run.side_effect = side_effect
-        yield mock_run
-
-
 class TestClientGenerator:
     """Tests for the ClientGenerator class."""
-    
-    def test_init_checks_generator_cli(self, mock_generator):
-        """Test that initialization checks for the openapi-generator-cli."""
-        generator = ClientGenerator()
-        mock_generator.assert_called_once()
-        
-    def test_init_with_missing_cli(self):
-        """Test initialization when openapi-generator-cli is not available."""
-        with mock.patch("subprocess.run", side_effect=FileNotFoundError()):
-            with pytest.raises(RuntimeError) as excinfo:
-                ClientGenerator()
-            assert "openapi-generator-cli is not available" in str(excinfo.value)
-    
-    def test_load_spec_from_file(self, spec_file, mock_generator):
+
+    def test_load_spec_from_file(self, spec_file):
         """Test loading a spec from a file."""
         generator = ClientGenerator()
         with mock.patch.object(SpecProcessor, "load_from_file") as mock_load:
@@ -102,8 +59,8 @@ class TestClientGenerator:
             result = generator.load_spec(spec_file)
             mock_load.assert_called_once_with(spec_file)
             assert result == {"openapi": "3.0.0"}
-    
-    def test_load_spec_from_url(self, mock_generator):
+
+    def test_load_spec_from_url(self):
         """Test loading a spec from a URL."""
         url = "https://example.com/openapi.yaml"
         generator = ClientGenerator()
@@ -112,161 +69,207 @@ class TestClientGenerator:
             result = generator.load_spec(url)
             mock_load.assert_called_once_with(url)
             assert result == {"openapi": "3.0.0"}
-    
-    def test_generate_client_without_loaded_spec(self, tmp_path, mock_generator):
+
+    def test_generate_client_without_loaded_spec(self, tmp_path):
         """Test generating a client without a loaded spec."""
         generator = ClientGenerator()
         with pytest.raises(ValueError) as excinfo:
             generator.generate_client(tmp_path)
         assert "No specification loaded" in str(excinfo.value)
-    
-    def test_generate_client(self, sample_spec, tmp_path, mock_generator):
+
+    def test_generate_client(self, sample_spec, tmp_path):
         """Test generating a client."""
-        generator = ClientGenerator()
-        generator.spec_processor.spec = sample_spec
-        
-        # Mock the file operations
-        with mock.patch("builtins.open", mock.mock_open()) as mock_file:
-            output_path = generator.generate_client(tmp_path)
-            assert output_path == Path(tmp_path)
-            
-            # Check that the spec was written to a temporary file
-            mock_file.assert_called()
-            
-            # Check that the generator was called with the right arguments
-            mock_generator.assert_called()
-            
-            # Check the last call to mock_generator
-            args, kwargs = mock_generator.call_args
-            cmd = args[0]
-            assert "openapi-generator-cli" in cmd
-            assert "generate" in cmd
-            assert "-g" in cmd
-            assert "python" in cmd
-    
-    def test_generate_client_with_config(self, sample_spec, tmp_path, mock_generator):
+        # Create instance of ClientGenerator with mocked dependencies
+        with mock.patch("openapi_mcp.client_generator.generate") as mock_generate:
+            mock_generate.return_value = []  # No errors
+
+            generator = ClientGenerator()
+            generator.spec_processor.spec = sample_spec
+
+            # Make TemporaryDirectory context manager return a predictable path
+            temp_dir = "/tmp/mock-temp-dir"
+            mock_temp_dir = mock.MagicMock()
+            mock_temp_dir.__enter__.return_value = temp_dir
+
+            with (
+                mock.patch("tempfile.TemporaryDirectory", return_value=mock_temp_dir),
+                mock.patch("builtins.open", mock.mock_open()),
+            ):
+
+                output_path = generator.generate_client(tmp_path)
+                assert output_path == Path(tmp_path)
+
+                # Verify generate was called
+                assert mock_generate.called
+
+    def test_generate_client_with_config(self, sample_spec, tmp_path):
         """Test generating a client with custom configuration."""
-        generator = ClientGenerator()
-        generator.spec_processor.spec = sample_spec
-        
-        config = {
+        user_config = {
             "packageName": "custom_package",
-            "library": "aiohttp",
+            "project_name_override": "CustomClient",
         }
-        
-        with mock.patch("builtins.open", mock.mock_open()) as mock_file:
-            generator.generate_client(tmp_path, config)
-            
-            # Check the last call to mock_generator
-            args, kwargs = mock_generator.call_args
-            cmd = args[0]
-            
-            # Check that the config options were included
-            assert "--additional-properties=packageName=custom_package" in cmd
-            assert "--additional-properties=library=aiohttp" in cmd
-    
-    def test_generate_client_subprocess_error(self, sample_spec, tmp_path, mock_generator):
-        """Test handling of subprocess errors during generation."""
-        generator = ClientGenerator()
-        generator.spec_processor.spec = sample_spec
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_result = mock.MagicMock()
-            mock_result.returncode = 1
-            mock_result.stderr = "Generation failed"
-            mock_run.return_value = mock_result
-            
-            with mock.patch("builtins.open", mock.mock_open()):
+
+        # Create a mock for generate that captures the config passed
+        generate_mock = mock.MagicMock(return_value=[])
+
+        with mock.patch("openapi_mcp.client_generator.generate", generate_mock):
+            generator = ClientGenerator()
+            generator.spec_processor.spec = sample_spec
+
+            # Make TemporaryDirectory context manager return a predictable path
+            temp_dir = "/tmp/mock-temp-dir"
+            mock_temp_dir = mock.MagicMock()
+            mock_temp_dir.__enter__.return_value = temp_dir
+
+            with (
+                mock.patch("tempfile.TemporaryDirectory", return_value=mock_temp_dir),
+                mock.patch("builtins.open", mock.mock_open()),
+            ):
+
+                generator.generate_client(tmp_path, user_config)
+
+                # Check the generator was called
+                generate_mock.assert_called_once()
+
+                # Get the config that was passed to generate
+                args, kwargs = generate_mock.call_args
+                assert "config" in kwargs
+
+    def test_generate_client_error(self, sample_spec, tmp_path):
+        """Test handling of errors during generation."""
+        from openapi_python_client import GeneratorError
+
+        # Mock a generation error - return list of errors
+        error = GeneratorError(header="Generation failed", detail="Error details")
+
+        # Create a mock for generate that returns an error
+        with mock.patch("openapi_mcp.client_generator.generate") as generate_mock:
+            generate_mock.return_value = [error]
+
+            generator = ClientGenerator()
+            generator.spec_processor.spec = sample_spec
+
+            # Make TemporaryDirectory context manager return a predictable path
+            temp_dir = "/tmp/mock-temp-dir"
+            mock_temp_dir = mock.MagicMock()
+            mock_temp_dir.__enter__.return_value = temp_dir
+
+            with (
+                mock.patch("tempfile.TemporaryDirectory", return_value=mock_temp_dir),
+                mock.patch("builtins.open", mock.mock_open()),
+            ):
+
                 with pytest.raises(RuntimeError) as excinfo:
                     generator.generate_client(tmp_path)
                 assert "Client generation failed" in str(excinfo.value)
-    
-    def test_validate_generated_client(self, tmp_path, mock_generator):
+
+    def test_validate_generated_client(self, tmp_path):
         """Test validating a generated client."""
         generator = ClientGenerator()
-        
+
         # Create a fake client directory structure
         client_dir = tmp_path / "client"
-        os.makedirs(client_dir / "openapi_client")
-        (client_dir / "openapi_client" / "__init__.py").touch()
-        (client_dir / "openapi_client" / "api_client.py").touch()
-        (client_dir / "setup.py").touch()
-        
+        package_dir = client_dir / "test_client"
+        os.makedirs(package_dir)
+        (package_dir / "__init__.py").touch()
+        (package_dir / "client.py").touch()
+        (client_dir / "pyproject.toml").touch()
+
         # Should validate successfully
         assert generator.validate_generated_client(client_dir) is True
-    
-    def test_validate_generated_client_missing_files(self, tmp_path, mock_generator):
+
+    def test_validate_generated_client_missing_files(self, tmp_path):
         """Test validating a client with missing files."""
         generator = ClientGenerator()
-        
+
         # Create an incomplete client directory structure
         client_dir = tmp_path / "client"
-        os.makedirs(client_dir / "openapi_client")
-        (client_dir / "openapi_client" / "__init__.py").touch()
-        # Missing api_client.py and setup.py
-        
+        package_dir = client_dir / "test_client"
+        os.makedirs(package_dir)
+        (package_dir / "__init__.py").touch()
+        # Missing client.py and pyproject.toml
+
         with pytest.raises(ValueError) as excinfo:
             generator.validate_generated_client(client_dir)
         assert "Invalid client: missing" in str(excinfo.value)
-    
-    def test_package_client(self, tmp_path, mock_generator):
+
+    def test_package_client(self, tmp_path):
         """Test packaging a generated client."""
         generator = ClientGenerator()
-        
+
         # Create a fake client directory structure
         client_dir = tmp_path / "client"
-        os.makedirs(client_dir / "openapi_client")
-        (client_dir / "openapi_client" / "__init__.py").touch()
-        (client_dir / "openapi_client" / "api_client.py").touch()
-        (client_dir / "setup.py").touch()
-        
+        package_dir = client_dir / "test_client"
+        os.makedirs(package_dir)
+        (package_dir / "__init__.py").touch()
+        (package_dir / "client.py").touch()
+        (client_dir / "pyproject.toml").touch()
+
         # Create a fake dist directory with a wheel
         os.makedirs(client_dir / "dist")
-        wheel_path = client_dir / "dist" / "openapi_client-1.0.0-py3-none-any.whl"
+        wheel_path = client_dir / "dist" / "test_client-1.0.0-py3-none-any.whl"
         wheel_path.touch()
-        
-        with mock.patch("os.chdir"):
+
+        with mock.patch("subprocess.run") as mock_run, mock.patch("os.chdir"):
+            mock_result = mock.MagicMock()
+            mock_result.returncode = 0
+            mock_run.return_value = mock_result
+
             result = generator.package_client(client_dir)
             assert result == wheel_path
-    
-    def test_package_client_with_output_path(self, tmp_path, mock_generator):
+
+    def test_package_client_with_output_path(self, tmp_path):
         """Test packaging a client with a custom output path."""
         generator = ClientGenerator()
-        
+
         # Create a fake client directory structure
         client_dir = tmp_path / "client"
-        os.makedirs(client_dir / "openapi_client")
-        (client_dir / "openapi_client" / "__init__.py").touch()
-        (client_dir / "openapi_client" / "api_client.py").touch()
-        (client_dir / "setup.py").touch()
-        
+        package_dir = client_dir / "test_client"
+        os.makedirs(package_dir)
+        (package_dir / "__init__.py").touch()
+        (package_dir / "client.py").touch()
+        (client_dir / "pyproject.toml").touch()
+
         # Create a fake dist directory with a wheel
         os.makedirs(client_dir / "dist")
-        wheel_path = client_dir / "dist" / "openapi_client-1.0.0-py3-none-any.whl"
+        wheel_path = client_dir / "dist" / "test_client-1.0.0-py3-none-any.whl"
         wheel_path.touch()
-        
+
         output_path = tmp_path / "output" / "custom.whl"
-        
-        with mock.patch("os.chdir"), mock.patch("shutil.copy") as mock_copy:
+
+        with (
+            mock.patch("subprocess.run") as mock_run,
+            mock.patch("os.chdir"),
+            mock.patch("shutil.copy") as mock_copy,
+        ):
+            mock_result = mock.MagicMock()
+            mock_result.returncode = 0
+            mock_run.return_value = mock_result
+
             result = generator.package_client(client_dir, output_path)
             assert result == output_path
             mock_copy.assert_called_once_with(wheel_path, output_path)
-    
-    def test_package_client_no_wheel(self, tmp_path, mock_generator):
+
+    def test_package_client_no_wheel(self, tmp_path):
         """Test packaging when no wheel is generated."""
         generator = ClientGenerator()
-        
+
         # Create a fake client directory structure
         client_dir = tmp_path / "client"
-        os.makedirs(client_dir / "openapi_client")
-        (client_dir / "openapi_client" / "__init__.py").touch()
-        (client_dir / "openapi_client" / "api_client.py").touch()
-        (client_dir / "setup.py").touch()
-        
+        package_dir = client_dir / "test_client"
+        os.makedirs(package_dir)
+        (package_dir / "__init__.py").touch()
+        (package_dir / "client.py").touch()
+        (client_dir / "pyproject.toml").touch()
+
         # Create an empty dist directory (no wheel)
         os.makedirs(client_dir / "dist")
-        
-        with mock.patch("os.chdir"):
+
+        with mock.patch("subprocess.run") as mock_run, mock.patch("os.chdir"):
+            mock_result = mock.MagicMock()
+            mock_result.returncode = 0
+            mock_run.return_value = mock_result
+
             with pytest.raises(RuntimeError) as excinfo:
                 generator.package_client(client_dir)
             assert "No wheel file found" in str(excinfo.value)

--- a/tests/unit/test_spec_processor.py
+++ b/tests/unit/test_spec_processor.py
@@ -22,11 +22,11 @@ class TestSpecProcessor(unittest.TestCase):
         processor = SpecProcessor()
         spec = processor.load_from_file(self.petstore_spec)
         self.assertIsNotNone(spec)
-        self.assertEqual(spec['info']['title'], "Petstore API")
-        self.assertEqual(spec['info']['version'], "1.0.0")
-        self.assertIn('paths', spec)
-        self.assertIn('/pets', spec['paths'])
-    
+        self.assertEqual(spec["info"]["title"], "Petstore API")
+        self.assertEqual(spec["info"]["version"], "1.0.0")
+        self.assertIn("paths", spec)
+        self.assertIn("/pets", spec["paths"])
+
     def test_load_spec_from_file_json(self):
         """Test loading an OpenAPI spec from a JSON file."""
         # Create a temporary JSON file with the OpenAPI spec
@@ -35,102 +35,101 @@ class TestSpecProcessor(unittest.TestCase):
             # Convert YAML to JSON and write to temp file
             processor = SpecProcessor()
             yaml_spec = processor.load_from_file(self.petstore_spec)
-            
+
             with open(temp_path, "w", encoding="utf-8") as temp_file:
                 json.dump(yaml_spec, temp_file)
-            
+
             # Load from JSON file
             processor = SpecProcessor()
             json_spec = processor.load_from_file(temp_path)
-            self.assertEqual(json_spec['info']['title'], "Petstore API")
-            self.assertEqual(json_spec['info']['version'], "1.0.0")
+            self.assertEqual(json_spec["info"]["title"], "Petstore API")
+            self.assertEqual(json_spec["info"]["version"], "1.0.0")
         finally:
             # Cleanup the temp file
             if temp_path.exists():
                 os.unlink(temp_path)
-    
+
     def test_load_spec_file_not_found(self):
         """Test error handling when file is not found."""
         processor = SpecProcessor()
         with self.assertRaises(FileNotFoundError):
             processor.load_from_file("/non/existent/file.yaml")
-    
+
     def test_load_spec_invalid_format(self):
         """Test error handling for invalid file format."""
         processor = SpecProcessor()
         with self.assertRaises(ValueError):
             processor.load_from_file(__file__)  # Try to load this Python file
 
-    @patch('requests.get')
+    @patch("requests.get")
     def test_load_spec_from_url(self, mock_get):
         """Test loading an OpenAPI spec from a URL."""
         # Create a mock response with the OpenAPI spec
         processor = SpecProcessor()
         yaml_spec = processor.load_from_file(self.petstore_spec)
-        
+
         mock_response = MagicMock()
         mock_response.json.return_value = yaml_spec
         mock_response.text = "dummy yaml content"
         mock_response.headers = {"Content-Type": "application/json"}
         mock_response.raise_for_status = MagicMock()
-        
+
         mock_get.return_value = mock_response
-        
+
         # Test loading from URL
         processor = SpecProcessor()
         spec = processor.load_from_url("https://example.com/api.json")
-        
-        self.assertEqual(spec['info']['title'], "Petstore API")
-        self.assertEqual(spec['info']['version'], "1.0.0")
+
+        self.assertEqual(spec["info"]["title"], "Petstore API")
+        self.assertEqual(spec["info"]["version"], "1.0.0")
         mock_get.assert_called_once_with("https://example.com/api.json", timeout=30)
 
     def test_validate_spec(self):
         """Test validating an OpenAPI specification."""
         processor = SpecProcessor()
         processor.load_from_file(self.petstore_spec)
-        
+
         # Valid spec should return True
         self.assertTrue(processor.validate_spec())
-        
+
         # Test with invalid spec
         processor = SpecProcessor()
         with self.assertRaises(ValueError):
             processor.validate_spec()  # No spec loaded
-    
+
     def test_extract_endpoints(self):
         """Test extracting API endpoints from the specification."""
         processor = SpecProcessor()
         processor.load_from_file(self.petstore_spec)
-        
+
         endpoints = processor.extract_endpoints()
         self.assertIsInstance(endpoints, list)
         self.assertGreater(len(endpoints), 0)
-        
+
         # Verify endpoint structure
         # Find an endpoint by path and method
         pets_endpoint = [
-            ep for ep in endpoints 
-            if ep['path'] == '/pets' and ep['method'] == 'GET'
+            ep for ep in endpoints if ep["path"] == "/pets" and ep["method"] == "GET"
         ][0]
-        self.assertEqual(pets_endpoint['operation_id'], 'listPets')
-        self.assertEqual(pets_endpoint['summary'], 'List all pets')
-        self.assertIn('parameters', pets_endpoint)
-    
+        self.assertEqual(pets_endpoint["operation_id"], "listPets")
+        self.assertEqual(pets_endpoint["summary"], "List all pets")
+        self.assertIn("parameters", pets_endpoint)
+
     def test_get_schemas(self):
         """Test extracting schema definitions from the specification."""
         processor = SpecProcessor()
         processor.load_from_file(self.petstore_spec)
-        
+
         schemas = processor.get_schemas()
         self.assertIsInstance(schemas, dict)
-        self.assertIn('Pet', schemas)
-        self.assertIn('NewPet', schemas)
-        
+        self.assertIn("Pet", schemas)
+        self.assertIn("NewPet", schemas)
+
         # Verify schema structure
-        pet_schema = schemas['Pet']
-        self.assertIn('properties', pet_schema)
-        self.assertIn('id', pet_schema['properties'])
-        self.assertIn('name', pet_schema['properties'])
+        pet_schema = schemas["Pet"]
+        self.assertIn("properties", pet_schema)
+        self.assertIn("id", pet_schema["properties"])
+        self.assertIn("name", pet_schema["properties"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Refactored client generator to use openapi-python-client library instead of openapi-generator-cli
- Eliminated Node.js dependency in favor of a pure Python implementation
- Updated tests to properly mock the new implementation
- Updated README and documentation to reflect the changes

## Test plan
- All unit tests passing
- Client generation from example petstore API works correctly
- Packaging functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)